### PR TITLE
Made it possible to use a function as a mock

### DIFF
--- a/src/Squire.js
+++ b/src/Squire.js
@@ -52,8 +52,9 @@ define(function() {
       for (alias in path) {
         this.mock(alias, path[alias]);
       }
+    } else {
+      this.mocks[path] = mock;
     }
-    this.mocks[path] = mock;
     
     return this;
   };
@@ -77,6 +78,17 @@ define(function() {
     for (path in this.mocks) {
       // Require.js code to the next require.
       define(path, this.mocks[path]);
+
+      // Wrap the mock in a function, to be able to use a function for a mock.
+      // If the function you want to use for a mock isn't wrapped in another function,
+      // Require.js automatically invokes your mock function.
+      var mockModule = function(path) {
+        return function() { 
+          return self.mocks[path];
+        };
+      }
+
+      define(path, mockModule(path));
     }
     
     this.load(dependencies, function() {


### PR DESCRIPTION
I have made a small change to the code making it possible to use functions as mocks. This is useful when you for example use Sinon.JS and need to inject a spy in place of the actual implementation.

The problem with the original code is that Require.JS apparently automatically invokes functions. I have fixed this by wrapping the mock in a function that simply return the mock.

I also fixed a small bug where the mocks was added to the mocks array, even if the path was of type `object`.
