### PR TITLE
add hooks for when something is required through container

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,10 @@
   "name": "Squire.js",
   "dependencies": {
     "grunt-mocha": "~0.1.3"
-  }
+  },
+  "version": "0.1.0",
+  "author": "Merrick Christensen <merrick.christensen@gmail.com> (http://www.merrickchristensen.com/)",
+  "contributors": [
+    "Jamison Dance <jergason@gmail.com> (http://jamisondance.com)"
+  ]
 }

--- a/src/Squire.js
+++ b/src/Squire.js
@@ -7,13 +7,21 @@ define(function() {
     var id = idCounter++;
     return 'context' + id;
   };
-  
+
   var Squire = function() {
     this.mocks = {};
     this._store = [];
+    this.requiredCallbacks = [];
     this.configure.apply(this, arguments);
   };
-  
+
+  /**
+   * Hook to call when the require function is called.
+   */
+  Squire.prototype.onRequired = function(cb) {
+    this.requiredCallbacks.push(cb);
+  }
+
   /**
    * Configuration of Squire.js, called from constructor or manually takes the
    * name of a require.js context to configure it.
@@ -21,31 +29,31 @@ define(function() {
   Squire.prototype.configure = function(context) {
     var configuration = {};
     var property;
-    
+
     this.id = uniqueId();
-    
+
     // Default the context
     if (typeof context === 'undefined') {
       context = '_'; // Default require.js context
     }
-    
+
     context = requirejs.s.contexts[context];
-    
+
     if ( ! context) {
       throw new Error('This context has not been created!');
     }
-    
+
     for (property in context.config) {
       if(property !== 'deps' && context.config.hasOwnProperty(property)) {
         configuration[property] = context.config[property];
       }
     }
-    
+
     configuration.context = this.id;
-    
+
     this.load = requirejs.config(configuration);
   };
-  
+
   Squire.prototype.mock = function(path, mock) {
     var alias;
     if (typeof path === 'object') {
@@ -54,53 +62,56 @@ define(function() {
       }
     }
     this.mocks[path] = mock;
-    
+
     return this;
   };
-  
+
   Squire.prototype.store = function(path) {
     this._store.push(path);
     return this;
   };
-  
+
   Squire.prototype.require = function(dependencies, callback) {
     var magicModuleName = 'mocks';
     var self = this;
     var path, magicModuleLocation;
-    
+
     magicModuleLocation = dependencies.indexOf(magicModuleName);
-    
+
     if (~magicModuleLocation) {
       dependencies.splice(magicModuleLocation, 1);
     }
-    
+
     for (path in this.mocks) {
       // Require.js code to the next require.
       define(path, this.mocks[path]);
     }
-    
+
     this.load(dependencies, function() {
       var store = {};
       var dependency;
-      
+
       if (~magicModuleLocation) {
         for (dependency in self._store) {
           store[self._store[dependency]] = requirejs.s.contexts[self.id].defined[self._store[dependency]];
         }
-        
+
         Array.prototype.splice.call(arguments, magicModuleLocation, 0, {
           mocks: self.mocks,
           store: store
         });
       }
-      
+
       callback.apply(null, arguments);
+      self.requiredCallbacks.forEach(function(cb) {
+        cb();
+      });
     });
   };
-  
+
   Squire.prototype.clean = function(mock) {
     var path;
-    
+
     if (mock && typeof mock === 'string') {
       requirejs.s.contexts[this.id].undef(mock);
       delete requirejs.s.contexts[this.id].defined[mock];
@@ -114,10 +125,10 @@ define(function() {
         this.clean(path);
       }
     }
-    
+
     return this;
   };
-  
+
   Squire.prototype.remove = function() {
     var path;
     for (path in requirejs.s.contexts[this.id].defined) {
@@ -125,6 +136,6 @@ define(function() {
     }
     delete requirejs.s.contexts[this.id];
   };
-  
+
   return Squire;
 });

--- a/test/tests/SquireTests.js
+++ b/test/tests/SquireTests.js
@@ -6,7 +6,7 @@ define(['Squire'], function(Squire) {
         var squireInstance = new Squire();
         squireInstance.should.be.an.instanceof(Squire);
       });
-            
+
       it('should throw an error if a context doesn\'t exist', function() {
         var create = function() {
           new Squire('not-real');
@@ -14,7 +14,7 @@ define(['Squire'], function(Squire) {
         create.should.Throw();
       });
     });
-    
+
     describe('require', function() {
       it('should require my specified dependencies', function(done) {
         var squire = new Squire();
@@ -23,7 +23,7 @@ define(['Squire'], function(Squire) {
           done();
         });
       });
-      
+
       it('should require a relative module', function(done) {
         var squire = new Squire();
         squire
@@ -35,10 +35,10 @@ define(['Squire'], function(Squire) {
             Formal.shirt.color.should.equal('Blue');
             done();
           });
-          
+
         squire.remove();
       });
-      
+
       it('should mock one of multiple dependencies', function(done) {
         var squire = new Squire();
         squire
@@ -51,7 +51,7 @@ define(['Squire'], function(Squire) {
             done();
           });
       });
-      
+
       it('should return my mocks to me using a magic module', function(done) {
         var squire = new Squire();
         squire
@@ -63,7 +63,7 @@ define(['Squire'], function(Squire) {
             done();
           });
       });
-      
+
       it('should return my dependencies to me using a magic module', function(done) {
         var squire = new Squire();
         squire
@@ -73,8 +73,17 @@ define(['Squire'], function(Squire) {
             done();
           });
       });
+
+      it('should call any onRequired hooks', function(done) {
+        var squire = new Squire();
+        squire.onRequired(function() {
+          done();
+        });
+
+        squire.require(['mocks/Shirt'], function (shirt) {});
+      });
     });
-    
+
     describe('mock', function() {
       it('should mock my dependency', function(done) {
         var squire = new Squire();
@@ -88,7 +97,7 @@ define(['Squire'], function(Squire) {
             done();
           });
       });
-      
+
       it('should allow a function as a dependency', function(done) {
         var squire = new Squire();
         squire
@@ -101,9 +110,9 @@ define(['Squire'], function(Squire) {
             Outfit.shirt().should.equal('Winter Blue');
             done();
           });
-          
+
       });
-      
+
       it('should mock my cjs dependency', function(done) {
         var squire = new Squire();
         squire
@@ -116,7 +125,7 @@ define(['Squire'], function(Squire) {
             done();
           });
       });
-      
+
       it('should not mock the dependency for other requires', function(done) {
         var squire = new Squire();
         squire
@@ -131,7 +140,7 @@ define(['Squire'], function(Squire) {
             });
           });
       });
-      
+
       it('should accept and object literal as an argument', function(done) {
         var squire = new Squire();
         squire
@@ -147,28 +156,28 @@ define(['Squire'], function(Squire) {
           });
       });
     });
-    
+
     describe('shared squire', function() {
       var squire = new Squire();
       squire.mock('mocks/Shirt', {
         color: 'Green',
         size: 'XLarge'
       });
-      
+
       it('should have a Green shirt', function(done) {
         squire.require(['mocks/Outfit'], function(Outfit) {
           Outfit.shirt.color.should.equal('Green');
           done();
         });
       });
-      
+
       it('should have an XLarge shirt size', function(done) {
         squire.require(['mocks/Formal'], function(Outfit) {
           Outfit.shirt.size.should.equal('XLarge');
           done();
         });
       });
-      
+
       it('should clean up the mocks if asked', function(done) {
         squire.clean();
         squire.require(['mocks/Shirt'], function(Shirt) {
@@ -176,7 +185,7 @@ define(['Squire'], function(Squire) {
           done();
         });
       });
-      
+
       it('should allow me to mock after a clean', function(done) {
         squire.clean();
         squire
@@ -190,7 +199,7 @@ define(['Squire'], function(Squire) {
           });
       });
     });
-    
+
     describe('clean', function() {
       it('should not mock the requested module', function(done) {
         var squire = new Squire();
@@ -198,7 +207,7 @@ define(['Squire'], function(Squire) {
           color: 'Clear',
           size: '?'
         });
-        
+
         squire
           .clean('mocks/Shirt')
           .require(['mocks/Outfit'], function(Outfit) {
@@ -206,28 +215,28 @@ define(['Squire'], function(Squire) {
             done();
           });
       });
-      
+
       it('should remove all mocks when called without args', function(done) {
         var squire = new Squire();
         squire.mock('mocks/Shirt', {
           color: 'Sky Blue'
         });
         squire.clean();
-        
+
         squire.require(['mocks/Shirt'], function(Shirt) {
           Shirt.color.should.equal('Red');
           done();
         });
-        
+
       });
-      
+
       it('should not mock the requested module by array', function(done) {
         var squire = new Squire();
         squire.mock('mocks/Shirt', {
           color: 'Clear',
           size: '?'
         });
-        
+
         squire
           .clean(['mocks/Shirt'])
           .require(['mocks/Outfit'], function(Outfit) {
@@ -236,6 +245,6 @@ define(['Squire'], function(Squire) {
           });
       });
     });
-    
+
   });
 });


### PR DESCRIPTION
See https://github.com/iammerrick/Squire.js/issues/9. Add hook to register callbacks that are called when a file is required through the container.

This is super dumb right now. It doesn't tell you anything about what was required or offer a way to clean them out, so if you are reusing the same container for different requires and/or want to clean them out between using the container, you are out of luck. This is enough for our needs though, so I was reluctant to add more complexity if it wasn't needed.

Thoughts?
