### PR TITLE
store() deps in array, Fixed clean(), added tests

### DIFF
--- a/src/Squire.js
+++ b/src/Squire.js
@@ -59,7 +59,13 @@ define(function() {
   };
   
   Squire.prototype.store = function(path) {
-    this._store.push(path);
+    if (path && typeof path === 'string') {
+      this._store.push(path);
+    } else if(path && Object.prototype.toString.apply(path) === '[object Array]') {
+      for (var i = 0; i < path.length; i++) {
+          this.store(path[i]);
+      }
+    }
     return this;
   };
   
@@ -105,9 +111,9 @@ define(function() {
       requirejs.s.contexts[this.id].undef(mock);
       delete requirejs.s.contexts[this.id].defined[mock];
       delete this.mocks[mock];
-    } else if(mock && typeof mock === 'array') {
-      for (path in mock) {
-        this.clean(path);
+    } else if(mock && Object.prototype.toString.apply(mock) === '[object Array]') {
+      for (var i = 0; i < mock.length; i++) {
+        this.clean(mock[i]);
       }
     } else {
       for (path in this.mocks) {

--- a/test/tests/SquireTests.js
+++ b/test/tests/SquireTests.js
@@ -63,18 +63,28 @@ define(['Squire'], function(Squire) {
             done();
           });
       });
-      
-      it('should return my dependencies to me using a magic module', function(done) {
-        var squire = new Squire();
-        squire
-          .store('mocks/Shirt')
-          .require(['mocks/Outfit', 'mocks'], function(Outfit, mocks) {
-            mocks.store['mocks/Shirt'].color.should.equal('Red');
-            done();
-          });
-      });
     });
-    
+    describe('store', function(){
+        it('should store the requested module', function(done){
+          var squire = new Squire();
+          squire
+            .store('mocks/Shirt')
+            .require(['mocks/Outfit', 'mocks'], function(Outfit, mocks){
+                mocks.store['mocks/Shirt'].color.should.equal('Red');
+                done();
+            });
+        });
+        it('should store all modules by array', function(done){
+          var squire = new Squire();
+          squire
+            .store(['mocks/Shirt','mocks/Pant'])
+            .require(['mocks/FullyDressed', 'mocks'], function(FullyDressed, mocks){
+                mocks.store['mocks/Shirt'].should.not.be.null;
+                mocks.store['mocks/Pant'].should.not.be.null;
+                done();
+            });
+        });
+    });
     describe('mock', function() {
       it('should mock my dependency', function(done) {
         var squire = new Squire();
@@ -227,11 +237,15 @@ define(['Squire'], function(Squire) {
           color: 'Clear',
           size: '?'
         });
+        squire.mock('mocks/Pant', {
+            type: 'Cowboy',
+        });
         
         squire
           .clean(['mocks/Shirt'])
-          .require(['mocks/Outfit'], function(Outfit) {
-            Outfit.shirt.color.should.equal('Red');
+          .require(['mocks/FullyDressed'], function(FullyDressed) {
+            FullyDressed.shirt.color.should.equal('Red');
+            FullyDressed.pant.type.should.equal('Cowboy');
             done();
           });
       });


### PR DESCRIPTION
I added the ability to store dependencies through array.
While doing this, I noticed the typeof path === 'array' which does not work.  According to the ecmascript standard, 'array' will never be returned.  This was used in the clean() method.

I made your existing tests more specific to expose the bug, and fixed both.
