### PR TITLE
Remove the dep after we have done with it, to avoid any object refs bein...

### DIFF
--- a/src/Squire.js
+++ b/src/Squire.js
@@ -176,6 +176,7 @@ define(function() {
       each(self.requiredCallbacks, function(cb) {
         cb.call(null, dependencies, args);
       });
+      self.clean(dependencies);
     });
   };
 

--- a/src/Squire.js
+++ b/src/Squire.js
@@ -176,7 +176,7 @@ define(function() {
       each(self.requiredCallbacks, function(cb) {
         cb.call(null, dependencies, args);
       });
-      self.clean(dependencies);
+      
     });
   };
 

--- a/test/tests/SquireTests.js
+++ b/test/tests/SquireTests.js
@@ -207,6 +207,36 @@ define(['Squire'], function(Squire) {
       });
     });
 
+
+   describe('CJS with reference', function() {
+      var squire = new Squire();
+       squire
+        .mock({
+          'mocks/Shirt' : {
+            color: 'Silver',
+            size: 'Small'
+          }
+        });
+      afterEach(function(done) {
+        squire.clean();
+        squire
+        .mock({
+          'mocks/Shirt' : {
+            color: 'Orange',
+            size: 'Small'
+          }
+        });
+        done();
+      });
+      it('Should use supplied mock', squire.run(['mocks/RefOutfit'], function(CJS) {
+        CJS.shirt.color.should.equal('Silver');
+      }));
+      it('should be using a different mock', squire.run(['mocks/RefOutfit'], function(CJS) {
+        CJS.shirt.color.should.equal('Orange');
+      }));
+
+    });
+
     describe('shared squire', function() {
       var squire = new Squire();
       squire.mock('mocks/Shirt', {


### PR DESCRIPTION
...g retained

I am almost positive this is the wrong approach, but it seems sane to me :)
Was having issues with any instances of objects being created inside a define() because require was caching the object we were requiring i was getting mocks that were referencing the objects required by the previous test.

This fixes it.
There is currently 1 failing test with relative modules. So don't merge this. Just want to start a discussion around this to try and find a solution if this is not the right approach. 
