### PR TITLE
Fix for object literal mocks

### DIFF
--- a/src/Squire.js
+++ b/src/Squire.js
@@ -123,8 +123,9 @@ define(function() {
       each(path, function(alias, key) {
         this.mock(key, alias);
       }, this);
+    } else {
+      this.mocks[path] = mock;
     }
-    this.mocks[path] = mock;
 
     return this;
   };

--- a/test/tests/SquireTests.js
+++ b/test/tests/SquireTests.js
@@ -200,7 +200,8 @@ define(['Squire'], function(Squire) {
               size: 'Small'
             }
           })
-          .require(['mocks/Outfit'], function(Outfit) {
+          .require(['mocks/Outfit', 'mocks'], function(Outfit, mocks) {
+            mocks.mocks.should.have.keys(['mocks/Shirt']);
             Outfit.shirt.color.should.equal('Silver');
             done();
           });

--- a/test/tests/SquireTests.js
+++ b/test/tests/SquireTests.js
@@ -35,7 +35,7 @@ define(['Squire'], function(Squire) {
       it('should require a relative module', function(done) {
         var squire = new Squire();
         squire
-          .mock(['mocks/Shirt'], {
+          .mock('mocks/Shirt', {
             color: 'Blue',
             size: 'Unknown'
           })
@@ -50,7 +50,7 @@ define(['Squire'], function(Squire) {
       it('should mock one of multiple dependencies', function(done) {
         var squire = new Squire();
         squire
-          .mock(['mocks/Pant'], {
+          .mock('mocks/Pant', {
             type: 'None'
           })
           .require(['mocks/FullyDressed'], function(FullyDressed) {


### PR DESCRIPTION
When passed an object as the path, the mock() method was iterating over the keys and adding them but also adding the object itself afterwards. The mocks object ends up looking something like:

```
{
  "mocks/Shirt": Object,
  "[object Object]": undefined
}
```

Incidentally, a couple of tests that were using arrays instead of strings for the path actually passed due to the above bug. After the array items had been iterated over, the array itself was used as a key in the mocks object and the string coercion produced the intended module name:

```
{
  "0": "mocks/Shirt"
  "mocks/Shirt": Object
}
```
