### PR TITLE
Implement AMD constructors that can be used with `new`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,23 @@ Squire.js offers a few helper functions to ease pains associated with mocking an
 
 ### Squire.Helpers.returns(Any what)
 
-Often times AMD modules return constructor functions which means that mocking such a class would end up having to create a function that returns a function that returns your mocked instance. Squire.js eases that pain by wrapping up your instance for you.
+Create a mock that returns mockViewInstance
 
 ```javascript
 injector.mock('Views/AwesomeView', Squire.Helpers.returns(mockViewInstance));
+```
+
+### Squire.Helpers.constructs(Any what)
+
+Often times AMD modules return constructor functions which means that mocking such a class would end up having to create a function that returns a function that returns your mocked instance. Squire.js eases that pain by wrapping up your instance for you.
+
+```javascript
+injector.mock('Views/AwesomeView', Squire.Helpers.constructs(mockViewInstance));
+```
+
+Now any module that uses `Views/AwesomeView` as a constructor dependency will use get your mock instead:
+
+```javascript
+// when invoked with in an Squire.injector.require call
+var awesome = new AwesomeView(); // awesome now gets your mockViewInstance
 ```

--- a/src/Squire.js
+++ b/src/Squire.js
@@ -237,5 +237,13 @@ define(function() {
     };
   };
 
+  Squire.Helpers.constructs = function(what) {
+    return function() {
+      return function() {
+        return what; 
+      };
+    };
+  };
+
   return Squire;
 });

--- a/test/tests/SquireTests.js
+++ b/test/tests/SquireTests.js
@@ -309,6 +309,17 @@ define(['Squire'], function(Squire) {
           definition().should.equal(instance);
         });
       });
+
+      describe('constructs', function() {
+        it('should create a function that returns a constructor to return what is passed', function() {
+          var instance = { type: 'Soda', flavor: 'Diet Coke'};
+          var definition = Squire.Helpers.constructs(instance);
+          var Definition = definition(); // simulates requirejs AMD module
+
+          var soda = new Definition();
+          soda.should.equal(instance);
+        }); 
+      })
     });
   });
 });


### PR DESCRIPTION
`Helpers.returns` creates a function that returns the `what`. Since require modules are invoked as functions, requiring the module mocked with `Helpers.returns` will be the mock instance rather than a constructor function, making it unusable with `new`.

Wrapping in one more function allows for proper constructors.

So now you can do this:

``` javascript
injector.mock('Views/AwesomeView', Squire.Helpers.constructs(mockViewInstance));
```

`Views/AwesomeView` is now defined as a function that returns a constructor function that returns the `what`

whereas using `Helpers.returns` defines `Views/AwesomeView` as a function that returns the `what`

I've set this as a new method, `Helpers.constructs`, instead of overriding `returns` to maintain backwards compatibility.

Thoughts?
