### PR TITLE
added main to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "squirejs",
+  "main": "./src/Squire",
   "devDependencies": {
     "grunt-mocha": "~0.1.3",
     "grunt": "~0.3.17"


### PR DESCRIPTION
I need to get the module path for Squire.js, so I added a main prop to package.json.

``` javascript
try {
    require('squirejs');
} catch (e) {
    var squirePath = require.resolve('squirejs');
}
```
