### PR TITLE
Better 'functions as a module' support

### DIFF
--- a/src/Squire.js
+++ b/src/Squire.js
@@ -10,6 +10,10 @@ define(function() {
     return toString.call(arr) === '[object Array]';
   };
   
+  var isFunction = function(func) {
+    return func && toString.call(func) === '[object Function]';
+  };
+  
   var indexOf = function(arr, search) {
     for (var i = 0, length = arr.length; i < length; i++) {
       if (arr[i] === search) {
@@ -153,7 +157,15 @@ define(function() {
     }
     
     each(this.mocks, function(mock, path) {
-      define(path, mock);
+	  var moduleMock = mock;
+	  /*If mock is a kind of init function,
+	  wrap it into the module definition function*/
+	  if(isFunction(mock)) {
+	    moduleMock = function() {
+		  return mock;
+		};
+	  }
+	  define(path, moduleMock);
     });
 
     this.load(dependencies, function() {

--- a/test/mocks/Shoes.js
+++ b/test/mocks/Shoes.js
@@ -1,0 +1,3 @@
+define(['mocks/Shirt'], function(module) {
+  throw new Error('fashion disaster');
+});

--- a/test/tests/SquireTests.js
+++ b/test/tests/SquireTests.js
@@ -114,11 +114,8 @@ define(['Squire'], function(Squire) {
       it('should call an errback when a dependency throws an error', function(done) {
         var squire = new Squire();
         squire
-          .mock('mocks/Shirt', function() {
-            throw new Error('fashion disaster');
-          })
-          .require(['mocks/Shirt'], chai.assert.fail, function(err) {
-            err.requireModules.should.deep.equal(['mocks/Shirt']);
+          .require(['mocks/Shoes'], chai.assert.fail, function(err) {
+            err.requireModules.should.deep.equal(['mocks/Shoes']);
             err.message.should.equal('fashion disaster');
             done();
           });
@@ -165,9 +162,7 @@ define(['Squire'], function(Squire) {
         var squire = new Squire();
         squire
           .mock('mocks/Shirt', function() {
-            return function() {
-              return 'Winter Blue';
-            };
+            return 'Winter Blue';
           })
           .require(['mocks/Outfit'], function(Outfit) {
             Outfit.shirt().should.equal('Winter Blue');


### PR DESCRIPTION
Now in order to mock dependency with some function e.g.:

```
sinon.spy();
```

you will need to wrap it into another function that is returns your mock func in such a way:

```
squire.mock('dependencyToMock', function() { return sinon.spy(); });
```

This pull request makes some changes in `Squire#require` method in order to check whether the mock dependency for the requested module is a function and if so wrap it into another function before passing to the require.js' `define` method.
So that it is no need to make that wrapping when calling `squire#mock`:

```
squire
    .mock('dependencyToMock', sinon.spy())
    .require(['modules/requiredModule'], function(RequiredModule) {
    // The RequiredModule's dependency 'dependencyToMock' has been mocked
    // to use the function returned by sinon.spy()
    ...
  });
```
