### PR TITLE
Ignore callbacks in the requirejs configuration as well.

### DIFF
--- a/src/Squire.js
+++ b/src/Squire.js
@@ -111,7 +111,7 @@ define(function() {
     }
 
     each(context.config, function(property, key) {
-      if (key !== 'deps') {
+      if (['deps', 'callback'].indexOf(key) === -1) {
         configuration[key] = property;
       }
     });


### PR DESCRIPTION
When the requirejs configuration contains a callback (http://requirejs.org/docs/api.html#config-callback) then  this callback will be executed on creation of the Squire object. I don't think this is intended.

I'm running karma with requirejs included (https://www.npmjs.org/package/karma-requirejs) and this requires a callback in the initial requirejs config in order to start the karma run after loading all dependencies.

This is my requirejs configuration:

```
require.config({
  // Karma serves files under /base, which is the basePath from your config file
  baseUrl: '/base',

  // dynamically load all test files
  deps: allTestFiles,

  // we have to kickoff karma, as it is asynchronous
  callback: window.__karma__.start
});
```

When Squire heeds the callback karma will start as often as possible until the first test run completes. If Squire ignores the callback everything looks normal.
