### PR TITLE
Illustrate (and resolve) Case without Context

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,9 @@ module.exports = function(grunt) {
           describe: true,
           it: true,
           mocha: true,
-          chai: true
+          chai: true,
+          beforeEach: true,
+          afterEach: true
         }
       },
       files: [

--- a/test/data-main-config.js
+++ b/test/data-main-config.js
@@ -4,5 +4,5 @@ requirejs.config({
     tests: '../test/tests',
     mocks: '../test/mocks'
   },
-  deps: ['tests/DepsRun']
+  deps: ['tests/DepsRun', 'tests/RemoveTests']
 });

--- a/test/tests.html
+++ b/test/tests.html
@@ -13,7 +13,7 @@
       mocha.setup('bdd');
       chai.should();
       require(['config'], function() {
-        require(['tests/SquireTests'], function() {
+        require(['tests/SquireTests', 'tests/RemoveTests'], function() {
           mocha.run();
         });
       });

--- a/test/tests/RemoveTests.js
+++ b/test/tests/RemoveTests.js
@@ -1,0 +1,31 @@
+define(['Squire'], function(Squire) {
+  describe('issue #34', function() {
+    var expect = chai.expect,
+        injector = new Squire(),
+        mock,
+        cleanRemoveWrapper = function() {
+          injector.clean();
+          injector.remove();
+        };
+
+    beforeEach(function(done) {
+      injector
+        .mock('mocks/Shirt', {
+          color: 'Blue',
+          size: 'Small'
+        })
+        .require(['mocks/Shirt'], function(_mock) {
+          mock = _mock;
+          done();
+        });
+    });
+
+    it('should not throw exception', function() {
+      expect(cleanRemoveWrapper).to.not.throw();
+    });
+
+    it('should STILL not throw exception', function() {
+      expect(cleanRemoveWrapper).to.not.throw();
+    });
+  });
+});


### PR DESCRIPTION
Hopefully this illustrates the series of events that would lead to the context being undefined as described in issue #34.

This set of tests currently fails with the message:

```
1) issue #34 should STILL not throw exception:
     AssertionError: expected [Function] to not throw an error but [TypeError: 'undefined' is not an object (evaluating 'context.undef')] was thrown
      at file:///Users/ryan/Source/Squire.js/test/vendor/chai.js:918
      at assertThrows (file:///Users/ryan/Source/Squire.js/test/vendor/chai.js:2049)
      at file:///Users/ryan/Source/Squire.js/test/vendor/chai.js:3522
      at file:///Users/ryan/Source/Squire.js/test/tests/RemoveTests.js:28
      at file:///Users/ryan/Source/Squire.js/test/vendor/mocha.js:4281
      at file:///Users/ryan/Source/Squire.js/test/vendor/mocha.js:4667
      at file:///Users/ryan/Source/Squire.js/test/vendor/mocha.js:4756
      at next (file:///Users/ryan/Source/Squire.js/test/vendor/mocha.js:4592)
      at file:///Users/ryan/Source/Squire.js/test/vendor/mocha.js:4602
      at next (file:///Users/ryan/Source/Squire.js/test/vendor/mocha.js:4540)
      at file:///Users/ryan/Source/Squire.js/test/vendor/mocha.js:4564
      at done (file:///Users/ryan/Source/Squire.js/test/vendor/mocha.js:4255)
      at file:///Users/ryan/Source/Squire.js/test/vendor/mocha.js:4267
      at file:///Users/ryan/Source/Squire.js/test/tests/RemoveTests.js:19
      at file:///Users/ryan/Source/Squire.js/src/Squire.js:183
      at file:///Users/ryan/Source/Squire.js/test/vendor/require-2.1.9.js:1604
      at file:///Users/ryan/Source/Squire.js/test/vendor/require-2.1.9.js:844
      at file:///Users/ryan/Source/Squire.js/test/vendor/require-2.1.9.js:1114
      at file:///Users/ryan/Source/Squire.js/test/vendor/require-2.1.9.js:757
      at file:///Users/ryan/Source/Squire.js/test/vendor/require-2.1.9.js:1381
```

More code needs to be written to actually fix this issue. @iammerrick wanted a test case that illustrated the when you would not have a context after running `clean` or `remove`.
