### PR TITLE
Fixed bug #48 - cannot mock an array

### DIFF
--- a/src/Squire.js
+++ b/src/Squire.js
@@ -161,7 +161,7 @@ define(function() {
     }
     
     each(this.mocks, function(mock, path) {
-      define(path, mock);
+      define(path,[], mock);
     });
 
     this.load(dependencies, function() {

--- a/test/tests/SquireTests.js
+++ b/test/tests/SquireTests.js
@@ -173,10 +173,11 @@ define(['Squire'], function(Squire) {
 
       it('should allow an array as a dependency', function (done) {
           var squire = new Squire();
+          var mockedModule = ['Ocean Blue'];
           squire
-            .mock('mocks/Shirt', ['Ocean Blue'])
+            .mock('mocks/Shirt', mockedModule)
             .require(['mocks/Outfit'], function (Outfit){
-                Outfit.shirt.should.deep.equal(['Ocean Blue']);
+                Outfit.shirt.should.equal(mockedModule);
                 done();
             });
 

--- a/test/tests/SquireTests.js
+++ b/test/tests/SquireTests.js
@@ -171,6 +171,17 @@ define(['Squire'], function(Squire) {
 
       });
 
+      it('should allow an array as a dependency', function (done) {
+          var squire = new Squire();
+          squire
+            .mock('mocks/Shirt', ['Ocean Blue'])
+            .require(['mocks/Outfit'], function (Outfit){
+                Outfit.shirt.should.deep.equal(['Ocean Blue']);
+                done();
+            });
+
+      });
+
       it('should mock my cjs dependency', function(done) {
         var squire = new Squire();
         squire


### PR DESCRIPTION
When registering a module, uses define(name, deps, callback) instead of define(name, callback).
This allows one to mock a module returning an array. 
Indeed, if an array is passed as the second parameter, Require will assume it references dependencies and  will try to load them.
