### PR TITLE
Universal Module Definition

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,11 @@ module.exports = function(grunt) {
     mocha: {
       files: ['test/tests.html', 'test/tests-with-main.html']
     },
+    mochaTest: {
+      "nodeIntegration": {
+        "src": ["test/nodeTest.js"]
+      }
+    },
     watch: {
       test: {
         files: ['test/**/*', 'src/**/*'],
@@ -47,14 +52,15 @@ module.exports = function(grunt) {
       }
     }
   });
-  
+
   grunt.loadNpmTasks('grunt-mocha');
+  grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-watch');
   
   /**
    * Register the default task!
    */
-  grunt.registerTask('default', ['jshint', 'mocha']);
+  grunt.registerTask('default', ['jshint', 'mocha', 'mochaTest']);
 
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "squirejs",
   "main": "./src/Squire",
+  "dependencies": {
+    "requirejs": "^2.1.2"
+  },
   "devDependencies": {
     "grunt-mocha": "~0.4.7",
     "grunt": "~0.4.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "grunt-mocha": "~0.4.7",
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.7.2",
-    "grunt-contrib-watch": "~0.5.3"
+    "grunt-contrib-watch": "~0.5.3",
+    "chai": "2.3.0",
+    "grunt-mocha-test": "0.12.7"
   },
   "repository": {
     "type": "git",

--- a/src/Squire.js
+++ b/src/Squire.js
@@ -1,5 +1,24 @@
-define(function() {
-  
+;(function (root, dependencies, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(factory);
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory.apply(this, dependencies.map(require));
+  } else {
+    // Browser globals (root is window)
+    root.returnExports = factory.apply(this, dependencies.map(function(module){return(root[module]);}));
+  }
+}(this, ['requirejs'], function (requirejsLoaded) {
+  if (typeof requirejs !== 'function') {
+    requirejs = requirejsLoaded;
+  }
+  if (typeof define !== 'function') {
+    define = requirejs.define;
+  }
+
   /**
    * Utility Functions
    */
@@ -254,4 +273,4 @@ define(function() {
   };
 
   return Squire;
-});
+}));

--- a/test/nodeTest.js
+++ b/test/nodeTest.js
@@ -1,0 +1,12 @@
+requirejs = require('requirejs');
+requirejs.config({
+  baseUrl: '',
+  paths: {
+    tests: 'test/tests',
+    mocks: 'test/mocks'
+  }
+});
+
+chai = require('chai');
+chai.should();
+require('./tests/SquireTests');

--- a/test/tests/SquireTests.js
+++ b/test/tests/SquireTests.js
@@ -1,5 +1,15 @@
 /*jshint expr:true */
-define(['Squire'], function(Squire) {
+;(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['Squire'], factory);
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory(require('../../src/Squire'));
+  }
+}(function (Squire) {
   describe('Squire', function() {
     describe('constructor', function() {
       it('should create an instance of Squire', function() {
@@ -192,7 +202,7 @@ define(['Squire'], function(Squire) {
             size: 'Medium'
           })
           .require(['mocks/CJSOutfit'], function(Outfit) {
-            require(['mocks/CJSOutfit'], function(NotTheMock) {
+            requirejs(['mocks/CJSOutfit'], function(NotTheMock) {
               NotTheMock.shirt.color.should.equal('Red');
               done();
             });
@@ -317,4 +327,4 @@ define(['Squire'], function(Squire) {
       });
     });
   });
-});
+}));


### PR DESCRIPTION
As discussed I have added UMD support to Squire, as well as an additional grunt task to test the code when required on the server side.
To do this I had to add "requirejs" as an explicit dependency in package.json

The tests are included as a separate commit. They incur a little bit of extra burden when changing the tests on the client side: configuration done outside of SquireTests.js needs to be duplicated in nodeTest.js

Please note that I did not bump the version number yet, as I am not sure what conventions for version numbers you use.
