### PR TITLE
Add try/catch blocks to handle async errors

### DIFF
--- a/src/Squire.js
+++ b/src/Squire.js
@@ -221,8 +221,12 @@ define(function() {
     var self = this;
     var run = function(done) {
       self.require(deps, function() {
-        callback.apply(null, arguments);
-        done();
+        try{
+          callback.apply(null, arguments);
+          done();
+        }catch(err){
+          done(err);
+        }
       });
     };
     


### PR DESCRIPTION
Make the run() method handle errors and provide them to done() callback. I decided that this would be great since I was getting timeouts errors (done() callback wasn't being called) when I was running tests in browser or with mocha-phantomjs. 

After this commit, errors were being displayed accordingly.
